### PR TITLE
#26 Change compare using to CollectionID from CollectionPath

### DIFF
--- a/web/concrete/blocks/autonav/templates/header_menu.php
+++ b/web/concrete/blocks/autonav/templates/header_menu.php
@@ -16,7 +16,7 @@
 				$target = 'target="' . $target . '"';
 			}
 
-			if ($ni->isActive($c) || strpos($c->getCollectionPath(), $_c->getCollectionPath()) === 0) {
+			if ($ni->isActive($c) || $c->getCollectionID() == $_c->getCollectionID()) {
 				$navSelected='nav-selected';
 			} else {
 				$navSelected = '';


### PR DESCRIPTION
パス名の先頭が重複している場合、例えばmemoとmemo9があった場合

memo9のページで、memoとmemo9のページがnav-selectedのクラスがつけられる。
コレクションＩＤで比較するように変更
