### PR TITLE
[エラー修正]　Fatal error: Using $this when not in object context in 〜/concrete/models/package.php on line 722

### DIFF
--- a/web/concrete/models/package.php
+++ b/web/concrete/models/package.php
@@ -719,7 +719,7 @@ class Package extends Object {
 				$pkg = Loader::package($p);
                 if (!empty($pkg)) {
 				    $packagesTemp[] = $pkg;
-				    $this->setupPackageLocalization();
+				    $pkg->setupPackageLocalization();
                 }
 			}
 			$packages = $packagesTemp;


### PR DESCRIPTION
[管理画面]→[concrete5を拡張]　で　エラー：Fatal error: Using $this when not in object context in 〜/concrete/models/package.php on line 722

[修正]
行番号722:                    $this->setupPackageLocalization();
↓
行番号722:                    $pkg->setupPackageLocalization();
