### PR TITLE
fixed short open tag

### DIFF
--- a/web/concrete/elements/collection_metadata.php
+++ b/web/concrete/elements/collection_metadata.php
@@ -131,14 +131,14 @@ if ($_REQUEST['approveImmediately'] == 1) {
 		<div class="clearfix">
 		<label for="cHandle"><?php echo t('Canonical URL')?></label>
 		<div class="input">
-		<?  if (!$c->isGeneratedCollection()) { ?>
-			<? echo BASE_URL . DIR_REL;?><?  if (URL_REWRITING == false) { ?>/<? echo DISPATCHER_FILENAME?><?  } ?><? 
+		<?php  if (!$c->isGeneratedCollection()) { ?>
+			<?php echo BASE_URL . DIR_REL;?><?php  if (URL_REWRITING == false) { ?>/<?php echo DISPATCHER_FILENAME?><?php  } ?><?php 
 			$cPath = substr($c->cPath, strrpos($c->cPath, '/') + 1);
 			print htmlentities(substr($c->cPath, 0, strrpos($c->cPath, '/')),ENT_QUOTES,APP_CHARSET)?>/<input type="text" name="cHandle" value="<?= htmlentities($cPath,ENT_QUOTES,APP_CHARSET)?>" id="cHandle" maxlength="128"><input type="hidden" name="oldCHandle" id="oldCHandle" value="<?= htmlentities($c->getCollectionHandle(),ENT_QUOTES,APP_CHARSET)?>"><br /><br />
-		<?   } else { ?>
+		<?php } else { ?>
 			<?= $c->getCollectionHandle()?><br /><br />
-		<?   } ?>
-			<span class="help-block"><? echo t('This page must always be available from at least one URL. That URL is listed above.')?></span>
+		<?php } ?>
+			<span class="help-block"><?php echo t('This page must always be available from at least one URL. That URL is listed above.')?></span>
 		</div>
 		</div>
 		<?php } ?>

--- a/web/concrete/elements/files/search_form_advanced.php
+++ b/web/concrete/elements/files/search_form_advanced.php
@@ -186,7 +186,7 @@ foreach($t1 as $value) {
 			<div class="input">
 				<select multiple name="fsID[]" class="chosen-select">
 					<optgroup label="<?=t('Sets')?>">
-					<? foreach($s1 as $s) { 
+					<?php foreach($s1 as $s) { 
 						$fsetName = $s->getFileSetName();
 						$i = 0;
 						$fsetName2 = array();
@@ -195,8 +195,8 @@ foreach($t1 as $value) {
 						}
 						$fsetName2 = implode("-",$fsetName2);
 					?>
-						<option value="<?=$s->getFileSetID()?>"  <? if ((is_array($searchRequest['fsID']) && in_array($s->getFileSetID(), $searchRequest['fsID'])) || (is_string($searchRequest['fsID']) && $searchRequest['fsID'] == $s->getFileSetID())) { ?> selected="selected" <? } ?>><?= $fsetName2;?></option>
-					<? } ?>
+						<option value="<?=$s->getFileSetID()?>"  <?php if ((is_array($searchRequest['fsID']) && in_array($s->getFileSetID(), $searchRequest['fsID'])) || (is_string($searchRequest['fsID']) && $searchRequest['fsID'] == $s->getFileSetID())) { ?> selected="selected" <?php } ?>><?= $fsetName2;?></option>
+					<?php } ?>
 					</optgroup>
 					<optgroup label="<?php echo t('Other')?>">
 						<option value="-1" <?php if ((is_array($searchRequest['fsID']) && in_array(-1, $searchRequest['fsID'])) || (is_string($searchRequest['fsID']) && $searchRequest['fsID'] == '-1')) { ?> selected="selected" <?php } ?>><?php echo t('Files in no sets.')?></option>


### PR DESCRIPTION
日本語版5.6.4.0にて、short_open_tagがOffの場合に、「ページの設定」の「ページパスロケーション」と「ファイルマネージャー」自体が正しく表示されません。
(Onのときは正しく表示されます）
原因はShortOpenTagの直し忘れのようでしたので、修正しました。

![base](https://user-images.githubusercontent.com/49182821/65560108-4a78a180-df78-11e9-9853-620b7b1c6218.png)
